### PR TITLE
 Normalize MP slugs; fix 17th LS “MP not found”

### DIFF
--- a/frontend/src/components/MPLADS/components/MPs/MPCard.jsx
+++ b/frontend/src/components/MPLADS/components/MPs/MPCard.jsx
@@ -3,7 +3,7 @@ import { FiUser, FiMapPin, FiTrendingUp, FiTrendingDown, FiMinus, FiCheckCircle,
 import InfoTooltip from '../Common/InfoTooltip';
 import './MPCard.css';
 import { formatINRCompact } from '../../../../utils/formatters';
-import { buildMPSlugHuman } from '../../../../utils/slug';
+import { buildMPSlugHuman, normalizeMPSlug } from '../../../../utils/slug';
 import { useFilters } from '../../../../contexts/FilterContext';
 
 const MPCard = ({ mp, rank }) => {
@@ -35,7 +35,7 @@ const MPCard = ({ mp, rank }) => {
 
   const { filters } = useFilters();
   const mpId = mp.id || mp._id;
-  const slug = buildMPSlugHuman(mp, { lsTerm: filters?.lsTerm });
+  const slug = normalizeMPSlug(buildMPSlugHuman(mp, { lsTerm: filters?.lsTerm }));
   // Use utilization percentage as primary metric
   const utilizationPercentage = mp.utilizationPercentage || 0;
   const completionRate = mp.completionRate || 

--- a/frontend/src/components/MPLADS/components/Search/SearchBar.jsx
+++ b/frontend/src/components/MPLADS/components/Search/SearchBar.jsx
@@ -7,7 +7,7 @@ import { useDebounce } from '../../../../hooks/useDebounce';
 import { useSearchMPs } from '../../../../hooks/useApi';
 import { sanitizeInput, sanitizeForSubmission } from '../../../../utils/inputSanitization';
 import './SearchBar.css';
-import { buildMPSlugHuman } from '../../../../utils/slug';
+import { buildMPSlugHuman, normalizeMPSlug } from '../../../../utils/slug';
 
 // A lean and robust search bar built from scratch.
 // - No suggestions dropdown
@@ -72,7 +72,7 @@ const SearchBar = ({ placeholder = 'Search MPs, constituencies, or projects...' 
 
     const id = match?._id || match?.id;
     if (id) {
-      const slug = buildMPSlugHuman(match, { lsTerm: filters?.lsTerm }) || String(id);
+      const slug = normalizeMPSlug(buildMPSlugHuman(match, { lsTerm: filters?.lsTerm }) || String(id));
       navigate(`/mplads/mps/${encodeURIComponent(slug)}`);
       return true;
     }
@@ -111,7 +111,7 @@ const SearchBar = ({ placeholder = 'Search MPs, constituencies, or projects...' 
         const s = suggestions[activeIndex];
         const id = s?._id || s?.id;
         if (id) {
-          const slug = buildMPSlugHuman(s, { lsTerm: filters?.lsTerm }) || String(id);
+          const slug = normalizeMPSlug(buildMPSlugHuman(s, { lsTerm: filters?.lsTerm }) || String(id));
           navigate(`/mplads/mps/${encodeURIComponent(slug)}`);
           setOpen(false);
           return;
@@ -184,7 +184,7 @@ const SearchBar = ({ placeholder = 'Search MPs, constituencies, or projects...' 
                     const id = s?._id || s?.id;
                     if (id) {
                       trackEngagement('mp_profile', id, 'suggestion_click');
-                      const slug = buildMPSlugHuman(s, { lsTerm: filters?.lsTerm }) || String(id);
+                      const slug = normalizeMPSlug(buildMPSlugHuman(s, { lsTerm: filters?.lsTerm }) || String(id));
                       navigate(`/mplads/mps/${encodeURIComponent(slug)}`);
                       setOpen(false);
                     }

--- a/frontend/src/components/MPLADS/pages/MPDetail.jsx
+++ b/frontend/src/components/MPLADS/pages/MPDetail.jsx
@@ -8,7 +8,7 @@ import InfoTooltip from '../components/Common/InfoTooltip';
 import ProjectListing from '../components/Projects/ProjectListing';
 import SkeletonLoader from '../components/Common/SkeletonLoader';
 import { showSuccessToast, showErrorToast } from '../../../utils/errorHandling.jsx';
-import { getIdFromSlug, isBareObjectId, buildMPSlugHuman, buildMPSlugCandidates } from '../../../utils/slug';
+import { getIdFromSlug, isBareObjectId, buildMPSlugHuman, buildMPSlugCandidates, normalizeMPSlug } from '../../../utils/slug';
 import { summaryAPI } from '../../../services/api';
 import { useFilters } from '../../../contexts/FilterContext';
 import './MPDetail.css';
@@ -88,7 +88,7 @@ const MPDetail = () => {
     if (!mp || mpLoading) return;
     // If URL has an ID (either as bare or trailing), canonicalize to human slug without ID
     if (idInParam || bareId) {
-      const human = buildMPSlugHuman(mp, { lsTerm: filters?.lsTerm });
+      const human = normalizeMPSlug(buildMPSlugHuman(mp, { lsTerm: filters?.lsTerm }));
       if (human) {
         // preserve the resolved id so data remains while URL updates
         if (!resolvedIdFromSlug) setResolvedIdFromSlug(idInParam || bareId);
@@ -107,7 +107,7 @@ const MPDetail = () => {
   useEffect(() => {
     if (effectiveId) return; // already have id
     if (!mpId || idInParam || bareId) return; // param has an id or is empty
-    const slug = String(mpId);
+    const slug = normalizeMPSlug(String(mpId));
 
     const LS_KEY = 'mplads_slug_index';
     const readIndex = () => {
@@ -189,7 +189,7 @@ const MPDetail = () => {
         <div className="performance-summary" style={{ marginTop: 16 }}>
           <div className="performance-cards">
             {ambiguousMatches.map((m) => {
-              const slug = buildMPSlugHuman(m, { lsTerm: filters?.lsTerm });
+              const slug = normalizeMPSlug(buildMPSlugHuman(m, { lsTerm: filters?.lsTerm }));
               const id = m._id || m.id;
               return (
                 <Link key={id} to={`/mplads/mps/${encodeURIComponent(slug)}`} className="performance-card" style={{ textDecoration: 'none' }}>

--- a/frontend/src/components/MPLADS/pages/SearchResults.jsx
+++ b/frontend/src/components/MPLADS/pages/SearchResults.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useSearchParams, Link } from 'react-router-dom';
 import { FiFilter, FiX, FiUser, FiMapPin, FiTrendingUp } from 'react-icons/fi';
 import { useMPSummary } from '../../../hooks/useApi';
-import { buildMPSlugHuman } from '../../../utils/slug';
+import { buildMPSlugHuman, normalizeMPSlug } from '../../../utils/slug';
 import { useFilters } from '../../../contexts/FilterContext';
 import SearchBar from '../components/Search/SearchBar';
 import FilterPanel from '../components/Filters/FilterPanel';
@@ -108,7 +108,7 @@ const SearchResults = () => {
                 {results.map((mp) => (
                   <Link 
                     key={mp._id || mp.id} 
-                    to={`/mplads/mps/${encodeURIComponent(buildMPSlugHuman(mp, { lsTerm: filters?.lsTerm }) || String(mp._id || mp.id))}`}
+                    to={`/mplads/mps/${encodeURIComponent(normalizeMPSlug(buildMPSlugHuman(mp, { lsTerm: filters?.lsTerm }) || String(mp._id || mp.id)))}`}
                     className="result-card"
                   >
                     <div className="result-header">

--- a/frontend/src/components/MPLADS/pages/StateDetail.jsx
+++ b/frontend/src/components/MPLADS/pages/StateDetail.jsx
@@ -8,7 +8,7 @@ import MPPersonalityDistribution from '../components/Charts/MPPersonalityDistrib
 import ProjectListing from '../components/Projects/ProjectListing';
 import './StateDetail.css';
 import { formatINRCompact } from '../../../utils/formatters';
-import { buildMPSlugHuman } from '../../../utils/slug';
+import { buildMPSlugHuman, normalizeMPSlug } from '../../../utils/slug';
 import { useFilters } from '../../../contexts/FilterContext';
 
 const StateDetail = () => {
@@ -500,7 +500,7 @@ const StateDetail = () => {
                     <div key={mp.id || mp._id} className="mobile-mp-card">
                       <div className="mp-card-header">
                         <div className="mp-primary-info">
-                          <Link to={`/mplads/mps/${encodeURIComponent(buildMPSlugHuman(mp, { lsTerm: filters?.lsTerm }) || String(mp.id || mp._id))}`} className="mp-name-link">
+                          <Link to={`/mplads/mps/${encodeURIComponent(normalizeMPSlug(buildMPSlugHuman(mp, { lsTerm: filters?.lsTerm }) || String(mp.id || mp._id)))}`} className="mp-name-link">
                             <h4>{mp.mpName || mp.name}</h4>
                           </Link>
                           <p className="mp-constituency">{mp.constituency}</p>
@@ -544,7 +544,7 @@ const StateDetail = () => {
                       {sortedMPs.map((mp) => (
                         <tr key={mp.id || mp._id}>
                           <td>
-                            <Link to={`/mplads/mps/${encodeURIComponent(buildMPSlugHuman(mp, { lsTerm: filters?.lsTerm }) || String(mp.id || mp._id))}`} className="mp-link">
+                            <Link to={`/mplads/mps/${encodeURIComponent(normalizeMPSlug(buildMPSlugHuman(mp, { lsTerm: filters?.lsTerm }) || String(mp.id || mp._id)))}`} className="mp-link">
                               {mp.mpName || mp.name}
                             </Link>
                           </td>


### PR DESCRIPTION
Summary: Some 17th Lok Sabha MP profile URLs contained the term token twice (e.g., …-17th-lok-sabha-17th-lok-sabha), causing      
  exact-match slug resolution to fail and show “MP not found”.
  - Fix: Introduce slug normalization to collapse duplicate house/term tokens and ensure a single suffix; apply normalization to both 
  link generation and slug resolution.                                                                                                
  - Key changes:                                                                                                                      
      - Add normalizeMPSlug() in frontend/src/utils/slug.js and return normalized slugs from buildMPSlugHuman() and                   
  buildMPSlugCandidates().                                                                                                            
      - Normalize incoming URL slugs and canonicalize to the normalized form in MPDetail.jsx.                                         
      - Update all MP links to use normalized slugs: MPCard.jsx, SearchBar.jsx, SearchResults.jsx, StateDetail.jsx.                   
      - Priority when multiple tokens present: ordinal-lok-sabha (e.g., 17th-lok-sabha) > lok-sabha > rajya-sabha.                    
  - Backward compatibility:                                                                                                           
      - Existing “double-tagged” URLs now resolve correctly; navigation canonicalizes the URL to the normalized slug.                 
      - No backend changes required.                                                                                                  
  - Test plan:                                                                                                                        
      - On MPLADS MPs, set term to 17th Lok Sabha; click multiple MP cards (e.g., Narendra Modi – Varanasi) and confirm profiles load.      - Manually append “-17th-lok-sabha” twice to any working 17th LS slug; it should still resolve and the URL should canonicalize  
  to a single suffix.                                                                                                                 
      - Verify links from MPs grid, search suggestions/results, and state page all use single-suffix slugs.                           
  - Risk: Low. Pure frontend slug handling; improves robustness of existing routes.                                                   
  - Fixes #18                  