### PR TITLE
feat: scroll to top of search when user click on next or previous

### DIFF
--- a/frontend/src/components/MPLADS/pages/SearchResults.jsx
+++ b/frontend/src/components/MPLADS/pages/SearchResults.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, useRef } from 'react';
 import { useSearchParams, Link } from 'react-router-dom';
 import { FiFilter, FiX, FiUser, FiMapPin, FiTrendingUp } from 'react-icons/fi';
 import { useMPSummary } from '../../../hooks/useApi';
@@ -20,6 +20,7 @@ const SearchResults = () => {
 
   const apiParams = useMemo(() => getApiParams(), [getApiParams]);
   const filterKey = useMemo(() => JSON.stringify(apiParams), [apiParams]);
+  const resultContentRef = useRef(null);
 
   useEffect(() => {
     setPageNo(1);
@@ -51,10 +52,18 @@ const SearchResults = () => {
 
   const changePage = (pageChangeDirection = 'next') => {
     if (pageChangeDirection === 'next') {
-      setPageNo(pageNo => pageNo + 1);
+      setPageNo(prev => Math.min(totalPages, prev + 1));
     } else {
-      setPageNo(pageNo => pageNo - 1);
+      setPageNo(prev => Math.max(1, prev - 1));
     }
+    setTimeout(() => {
+      if (resultContentRef) {
+        resultContentRef.current.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+       });
+      }
+    }, 10);
   }
 
   const getUtilizationColor = (percentage) => {
@@ -73,7 +82,7 @@ const SearchResults = () => {
   };
 
   return (
-    <div className="search-results-page">
+    <div className="search-results-page" ref={resultContentRef}>
       <div className="search-header">
         <div className="search-header-content">
           <h1>Search Results</h1>
@@ -184,7 +193,7 @@ const SearchResults = () => {
                   variant="outline"
                   disabled={!canGoPrev}
                   className="pagination-btn"
-                  onClick={() => setPageNo(prev => Math.max(1, prev - 1))}
+                  onClick={() => changePage('prev')}
                 >
                   Previous
                 </Button>
@@ -195,7 +204,7 @@ const SearchResults = () => {
                   variant="outline"
                   disabled={!canGoNext}
                   className="pagination-btn"
-                  onClick={() => setPageNo(prev => Math.min(totalPages, prev + 1))}
+                  onClick={() => changePage('next')}
                 >
                   Next
                 </Button>


### PR DESCRIPTION
Fixing the enhancement mentioned in #41 .
> Given that this PR is not closed I think we can add one more enhancement. Whenever someone clicks on next button, user should be scrolled up to the top of the search result for better UX.

https://github.com/user-attachments/assets/f1d4225c-e64e-4060-93a1-a7b2f9f66da6

